### PR TITLE
Set chiefComplaint slice path to coding.code

### DIFF
--- a/input/fsh/ServiceRequestSelfReferralSEVendorLite.fsh
+++ b/input/fsh/ServiceRequestSelfReferralSEVendorLite.fsh
@@ -12,7 +12,7 @@ Description: "This profile aims to support use cases concerning nationally defin
   * ^comment = "Only one reason code is supported by most vendors, hence constrained to 0..1"
 
 * reasonCode ^slicing.discriminator.type = #pattern
-* reasonCode ^slicing.discriminator.path = "code"
+* reasonCode ^slicing.discriminator.path = "coding.code"
 * reasonCode ^slicing.rules = #closed
 * reasonCode ^slicing.description = "Unordered, closed, by coding.code"
 * reasonCode contains


### PR DESCRIPTION
Attempted to fix a bug where the slicing discriminator path was set to code, but instead, it should be set to coding.code