### PR TITLE
Fixed regex to only allow 10 digits

### DIFF
--- a/input/fsh/invariants/organisationsnummer-invariant.fsh
+++ b/input/fsh/invariants/organisationsnummer-invariant.fsh
@@ -1,5 +1,5 @@
 Invariant: organisationsnummer-invariant
-Description: "All identifiers that identifies as organisationsnummer SHALL comply with the specified regex:\\d{10}"
-Expression: "$this.toString().matches('\\\\d{10}')"
+Description: "All identifiers that identifies as organisationsnummer SHALL comply with the specified regex:^\\d{10}$"
+Expression: "$this.toString().matches('^\\\\d{10}$')"
 Severity: #error
 XPath: "f:value"


### PR DESCRIPTION
Updated the regex to only allow for 10 digits, as opposed to the previous version which allowed for any string as long as it contained 10 digits in a row somewhere in the string.